### PR TITLE
Add callouts API documentation

### DIFF
--- a/docs/api-guides/callouts.md
+++ b/docs/api-guides/callouts.md
@@ -62,7 +62,7 @@ The trigger column itself is excluded from `changedFields` — only side-effect 
 
 | Status | Condition |
 |--------|-----------|
-| 400 | Missing or invalid `columnName`, `value`, `record`, or `recordId` |
+| 400 | Missing `columnName`; malformed `record` or `recordId`; or invalid `value` type for the target column (`null` is allowed to clear) |
 | 403 | User role does not have access to the window |
 | 404 | Window, tab, column, or record not found |
 | 500 | Callout execution error |
@@ -91,7 +91,7 @@ Error body example:
 
 ## Field Metadata: hasCallout Flag
 
-The fields metadata endpoint on windows also includes a `hasCallout` boolean flag for each field:
+The Window fields metadata endpoint also includes a `hasCallout` boolean flag for each field:
 
 **GET** `/api/v1/windows/{windowSlug}/{tabSlug}/fields`
 

--- a/docs/api-guides/callouts.md
+++ b/docs/api-guides/callouts.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Callouts API
 
-Execute field-level callouts without saving records via `/api/v1/callout`.
+Execute field-level callouts without saving records via `/api/v1/callout/{windowSlug}/{tabSlug}`.
 
 This endpoint allows client applications to fire iDempiere callouts and retrieve the changed fields — all without persisting anything to the database. This is useful for building dynamic UIs that react to field changes in real time.
 
@@ -80,7 +80,7 @@ Error body example:
 ## How It Works
 
 1. The endpoint resolves the window and tab from the URL slugs using base-language names, so it works consistently across locales.
-2. If `recordId` is provided and greater than 0, the existing record is loaded. Otherwise, a new record context is initialized.
+2. If `recordId` is provided and greater than 0, the existing record is loaded. Otherwise, a new record is initialized.
 3. Field values from `record` are applied to set up the context.
 4. A snapshot of all field values is taken (before state).
 5. The trigger column is set to `value`, which fires any registered callouts via `GridTab.processFieldChange()`.
@@ -98,8 +98,7 @@ The Window fields metadata endpoint also includes a `hasCallout` boolean flag fo
 ```json
 {
   "columnName": "M_Product_ID",
-  "hasCallout": true,
-  ...
+  "hasCallout": true
 }
 ```
 

--- a/docs/api-guides/callouts.md
+++ b/docs/api-guides/callouts.md
@@ -1,0 +1,111 @@
+---
+sidebar_position: 5
+---
+
+# Callouts API
+
+Execute field-level callouts without saving records via `/api/v1/callout`.
+
+This endpoint allows client applications to fire iDempiere callouts and retrieve the changed fields — all without persisting anything to the database. This is useful for building dynamic UIs that react to field changes in real time.
+
+---
+
+## Fire a Callout
+
+**POST** `/api/v1/callout/{windowSlug}/{tabSlug}`
+
+Execute callouts triggered by a field value change and return the fields that were modified.
+
+### URL Parameters
+
+- `{windowSlug}`: The slug (lowercase, hyphenated) of the window name. Example: `sales-order`
+- `{tabSlug}`: The slug of the tab name. Example: `order-line`
+
+### Body
+
+```json
+{
+  "columnName": "M_Product_ID",
+  "value": 123,
+  "record": {
+    "C_BPartner_ID": 100,
+    "M_Warehouse_ID": 103
+  },
+  "recordId": 0
+}
+```
+
+- `columnName` (required): The column whose value change triggers the callout.
+- `value` (required): The new value for the trigger column. Use `null` to clear the field.
+- `record` (optional): An object of existing field values to set on the record before firing the callout. This provides context so the callout can read related field values.
+- `recordId` (optional): The ID of an existing record to load as context. Use `0` or omit for a new (unsaved) record.
+
+### Returns
+
+A JSON object with a `changedFields` property containing only the fields that were modified by the callout:
+
+```json
+{
+  "changedFields": {
+    "C_UOM_ID": 100,
+    "M_AttributeSetInstance_ID": 0,
+    "QtyOrdered": 1
+  }
+}
+```
+
+:::tip
+The trigger column itself is excluded from `changedFields` — only side-effect changes are returned.
+:::
+
+### Error Responses
+
+| Status | Condition |
+|--------|-----------|
+| 400 | Missing or invalid `columnName`, `value`, `record`, or `recordId` |
+| 403 | User role does not have access to the window |
+| 404 | Window, tab, column, or record not found |
+| 500 | Callout execution error |
+
+Error body example:
+
+```json
+{
+  "error": "Window not found: invalid-window"
+}
+```
+
+---
+
+## How It Works
+
+1. The endpoint resolves the window and tab from the URL slugs using base-language names, so it works consistently across locales.
+2. If `recordId` is provided and greater than 0, the existing record is loaded. Otherwise, a new record context is initialized.
+3. Field values from `record` are applied to set up the context.
+4. A snapshot of all field values is taken (before state).
+5. The trigger column is set to `value`, which fires any registered callouts via `GridTab.processFieldChange()`.
+6. A second snapshot is compared against the first to detect which fields changed.
+7. The record is discarded — nothing is saved to the database.
+
+---
+
+## Field Metadata: hasCallout Flag
+
+The fields metadata endpoint on windows also includes a `hasCallout` boolean flag for each field:
+
+**GET** `/api/v1/windows/{windowSlug}/{tabSlug}/fields`
+
+```json
+{
+  "columnName": "M_Product_ID",
+  "hasCallout": true,
+  ...
+}
+```
+
+This flag is `true` when the field has callouts registered via either:
+
+- **AD_Column.Callout** — traditional callout class references configured in the Application Dictionary
+- **IColumnCalloutFactory** — OSGi-based callout plugins discovered at runtime via `Core.findCallout()`
+
+Client applications can use this flag to show visual indicators on fields that have automatic side effects.


### PR DESCRIPTION
## Summary
- Add documentation for the new `POST /api/v1/callout/{windowSlug}/{tabSlug}` endpoint
- Cover request/response format, parameters, error codes, and how it works internally
- Document the `hasCallout` boolean flag on field metadata endpoint

Related PR: https://github.com/bxservice/idempiere-rest/pull/479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Callouts API documentation covering endpoint usage, request/response formats, and error responses.
  * Clarified how field-level callouts operate during evaluation (non-persistent execution) and included examples of input/output expectations.
  * Documented Field Metadata support with a hasCallout indicator to identify fields that trigger registered callouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->