### PR TITLE
docs(api-guides): add Archives API page

### DIFF
--- a/docs/api-guides/archives.md
+++ b/docs/api-guides/archives.md
@@ -74,7 +74,8 @@ Retrieves the content of a single archive entry.
 **Returns:**
 
 - By default, the file content as `application/octet-stream` (for example, a PDF).
-- With `json`, a JSON object: `name`, `contentType`, and `data` (base64 encoded content).
+  The MIME type is returned in the `Content-Type` response header.
+- With `json`, a JSON object with a single `data` field holding the base64 encoded content.
 
 **Example (base64):**
 
@@ -84,8 +85,6 @@ GET /api/v1/models/c_invoice/1000045/archives/1000123?json=true
 
 ```json
 {
-  "name": "Invoice_1000045.pdf",
-  "contentType": "application/pdf",
   "data": "JVBERi0xLjQ..."
 }
 ```

--- a/docs/api-guides/archives.md
+++ b/docs/api-guides/archives.md
@@ -1,0 +1,100 @@
+---
+sidebar_position: 7
+---
+
+# Archives API
+
+iDempiere stores generated documents — most commonly printed report PDFs such as
+invoices — as **archives** (`AD_Archive` records) tied to the originating record.
+The Archives API lets you list and download these previously generated documents.
+
+This is different from the [Print endpoint](./other-resources/print.md), which always
+**re-renders** the document on demand. The archive endpoints return the **existing**
+stored binaries, exactly as they were generated.
+
+The same endpoints are available under `api/v1/views` for [REST Views](./rest-views.md),
+where they behave identically but operate on the configured view instead of the raw model.
+
+---
+
+## `GET /api/v1/models/{tableName}/{id}/archives`
+
+Lists the archives of a record, most recent first.
+
+**Path Parameters:**
+
+- `tableName`: Table name (e.g. `c_invoice`)
+- `id`: Record id (integer) or record uuid
+
+**Returns:**
+
+An `archives` array, each entry containing:
+
+- `id`: `AD_Archive_ID` of the archive entry
+- `name`: Archive name (when set)
+- `contentType`: MIME type of the archive (e.g. `application/pdf`)
+- `isReport`: `true` when the archive was produced by a report/print
+- `processId`: `AD_Process_ID` that generated the archive (when set)
+- `created`: Timestamp the archive was created
+
+**Example:**
+
+```json
+{
+  "archives": [
+    {
+      "id": 1000123,
+      "name": "Invoice_1000045.pdf",
+      "contentType": "application/pdf",
+      "isReport": true,
+      "processId": 110,
+      "created": "2026-06-19 09:00:00.0"
+    }
+  ]
+}
+```
+
+---
+
+## `GET /api/v1/models/{tableName}/{id}/archives/{archiveId}`
+
+Retrieves the content of a single archive entry.
+
+**Path Parameters:**
+
+- `tableName`: Table name (e.g. `c_invoice`)
+- `id`: Record id (integer) or record uuid
+- `archiveId`: `AD_Archive_ID` of the archive entry (from the list endpoint above)
+
+**Query Parameter (optional):**
+
+- `json`: When not empty, returns a JSON object with base64 encoded content
+  instead of the raw binary stream.
+
+**Returns:**
+
+- By default, the file content as `application/octet-stream` (for example, a PDF).
+- With `json`, a JSON object: `name`, `contentType`, and `data` (base64 encoded content).
+
+**Example (base64):**
+
+```
+GET /api/v1/models/c_invoice/1000045/archives/1000123?json=true
+```
+
+```json
+{
+  "name": "Invoice_1000045.pdf",
+  "contentType": "application/pdf",
+  "data": "JVBERi0xLjQ..."
+}
+```
+
+---
+
+:::note
+Archives are system-generated and read-only through the REST API. To produce a new
+archive, run the relevant print/report (see the
+[Processes API](./processes.md)); to upload arbitrary files against a record, use
+[Attachments or the Uploads API](./uploads.md).
+:::


### PR DESCRIPTION
Documents the archive read endpoints added to the REST API in bxservice/idempiere-rest#507 / #508, as requested by @d-ruiz on that PR.

## New page: `docs/api-guides/archives.md` ("Archives API")

Covers:
- `GET /api/v1/models/{tableName}/{id}/archives` — list archives of a record (most recent first)
- `GET /api/v1/models/{tableName}/{id}/archives/{archiveId}` — download content (binary, or base64 JSON via the `json` query param)
- Notes the equivalent endpoints under `api/v1/views`

Clarifies the distinction from the re-rendering Print endpoint, and links to the related Processes / Uploads pages.

`npm run build` passes (broken-link check clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)